### PR TITLE
lock version of kind, bump default k8s image

### DIFF
--- a/playbooks/create_cluster.yaml
+++ b/playbooks/create_cluster.yaml
@@ -1,0 +1,30 @@
+---
+- name: "Check if KinD Cluster already exists: {{ kind_cluster_name }}"
+  community.docker.docker_container_info:
+    name: "{{ kind_cluster_name + '-control-plane' }}"
+  register: cluster_check_result
+
+- name: "Start KinD Cluster: '{{ kind_cluster_name }}'"
+  command:
+    argv:
+      - "{{ inventory_dir }}/.resources/kind-{{ kind_version }}"
+      - create
+      - cluster
+      - --name={{ kind_cluster_name }}
+      - --image={{ kind_image_version }}
+      - --config={{ kind_config_file }}
+  register: kind_cluster_command
+  when: not cluster_check_result.exists
+
+- name: Echo output of "kind create cluster ..." command
+  ansible.builtin.debug:
+    msg: "{{ kind_cluster_command.stderr.split('\n') }}"
+  when: kind_cluster_command is not skipped
+
+- name: "Export kubeconfig for KinD Cluster: '{{ kind_cluster_name }}'"
+  command:
+    argv:
+      - "{{ inventory_dir }}/.resources/kind-{{ kind_version }}"
+      - export
+      - kubeconfig
+      - --name={{ kind_cluster_name }}

--- a/playbooks/kind.yaml
+++ b/playbooks/kind.yaml
@@ -6,5 +6,6 @@
     - metallb
   vars:
     kind_cluster_name: ansible
-    kind_image_version: kindest/node:v1.18.15
+    kind_version: v0.11.1
+    kind_image_version: kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
     kind_kubectl_default_namespace: seldon

--- a/roles/kind/defaults/main.yaml
+++ b/roles/kind/defaults/main.yaml
@@ -1,6 +1,10 @@
 ---
 kind_cluster_name: ansible
-kind_image_version: kindest/node:v1.18.15
+kind_image_version: kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
+
+kind_url:  "https://kind.sigs.k8s.io/dl/{{ kind_version }}/kind-linux-amd64"
+kind_version: v0.11.1
+kind_download_cli: true
 
 kind_kubectl_default_namespace: null
 kind_config_file: null

--- a/roles/kind/tasks/default_namespace.yaml
+++ b/roles/kind/tasks/default_namespace.yaml
@@ -1,0 +1,18 @@
+---
+- name: "Create a k8s namespace: {{ kind_kubectl_default_namespace }}"
+  community.kubernetes.k8s:
+    name: "{{ kind_kubectl_default_namespace }}"
+    api_version: v1
+    kind: Namespace
+    state: present
+  when: kind_kubectl_default_namespace is not none
+
+- name: "Set default for kubectl namespace: {{ kind_kubectl_default_namespace }}"
+  command:
+    argv:
+      - kubectl
+      - config
+      - set-context
+      - --current
+      - --namespace={{ kind_kubectl_default_namespace }}
+  when: kind_kubectl_default_namespace is not none

--- a/roles/kind/tasks/download_kind.yaml
+++ b/roles/kind/tasks/download_kind.yaml
@@ -1,0 +1,24 @@
+---
+- name: Check if Kind {{ kind_version }} already downloaded
+  stat:
+    path: "{{ inventory_dir }}/.resources/kind-{{ kind_version }}"
+  register: kind_binary
+
+- name: "Create .resources directory if does not exist: {{ inventory_dir }}/.resources/"
+  ansible.builtin.file:
+    path: "{{ inventory_dir }}/.resources/"
+    state: directory
+    mode: '0755'
+
+- name: Download Kind {{ kind_version }} binary
+  shell: "curl -Lo kind-{{ kind_version }} {{ kind_url }}"
+  args:
+    chdir: "{{ inventory_dir }}/.resources"
+    warn: false
+  when: kind_binary.stat.exists == false
+
+- name: Make Kind {{ kind_version }} binary executable
+  ansible.builtin.file:
+    path: "{{ inventory_dir }}/.resources/kind-{{ kind_version }}"
+    state: file
+    mode: '0755'

--- a/roles/kind/tasks/main.yaml
+++ b/roles/kind/tasks/main.yaml
@@ -1,53 +1,10 @@
 ---
-- name: "Check if KinD Cluster already exists: {{ kind_cluster_name }}"
-  community.docker.docker_container_info:
-    name: "{{ kind_cluster_name + '-control-plane' }}"
-  register: cluster_check_result
+- name: Get Kind Binary
+  include: download_kind.yaml
+  when: kind_download_cli | bool
 
+- name: Create Kind Cluster
+  include: create_cluster.yaml
 
-- name: "Start KinD Cluster: '{{ kind_cluster_name }}'"
-  command:
-    argv:
-      - kind
-      - create
-      - cluster
-      - --name={{ kind_cluster_name }}
-      - --image={{ kind_image_version }}
-      - --config={{ kind_config_file }}
-  register: kind_cluster_command
-  when: not cluster_check_result.exists
-
-
-- name: Echo output of "kind create cluster ..." command
-  ansible.builtin.debug:
-    msg: "{{ kind_cluster_command.stderr.split('\n') }}"
-  when: kind_cluster_command is not skipped
-
-
-- name: "Export kubeconfig for KinD Cluster: '{{ kind_cluster_name }}'"
-  command:
-    argv:
-      - kind
-      - export
-      - kubeconfig
-      - --name={{ kind_cluster_name }}
-
-
-- name: "Create a k8s namespace: {{ kind_kubectl_default_namespace }}"
-  community.kubernetes.k8s:
-    name: "{{ kind_kubectl_default_namespace }}"
-    api_version: v1
-    kind: Namespace
-    state: present
-  when: kind_kubectl_default_namespace is not none
-
-
-- name: "Set default for kubectl namespace: {{ kind_kubectl_default_namespace }}"
-  command:
-    argv:
-      - kubectl
-      - config
-      - set-context
-      - --current
-      - --namespace={{ kind_kubectl_default_namespace }}
-  when: kind_kubectl_default_namespace is not none
+- name: Create and set default namespace
+  include: default_namespace.yaml


### PR DESCRIPTION
- Add logic that gets kind binary of desired version.
- Bumps default k8s version to 1.20. Also use SHA of kindest/node image.