### PR TITLE
add metrics server to kind

### DIFF
--- a/roles/kind/defaults/main.yaml
+++ b/roles/kind/defaults/main.yaml
@@ -8,3 +8,6 @@ kind_download_cli: true
 
 kind_kubectl_default_namespace: null
 kind_config_file: null
+
+kind_deploy_metrics_server: true
+metrics_server_version: v0.5.0

--- a/roles/kind/tasks/main.yaml
+++ b/roles/kind/tasks/main.yaml
@@ -8,3 +8,7 @@
 
 - name: Create and set default namespace
   include: default_namespace.yaml
+
+- name: Deploy metrics server
+  include: metrics_server.yaml
+  when: kind_deploy_metrics_server | bool

--- a/roles/kind/tasks/metrics_server.yaml
+++ b/roles/kind/tasks/metrics_server.yaml
@@ -1,0 +1,25 @@
+---
+# Credits to Geerlingguy https://github.com/kubernetes-sigs/kind/issues/398#issuecomment-682072236
+
+- name: Download metrics-server manifest.
+  get_url:
+    url: https://github.com/kubernetes-sigs/metrics-server/releases/download/{{ metrics_server_version }}/components.yaml
+    dest: /tmp/metrics-server.yaml
+    mode: 0644
+
+- name: Modify the manifest to allow insecure TLS for testing.
+  lineinfile:
+    path: /tmp/metrics-server.yaml
+    state: present
+    regexp: "^.+{{ item }}$"
+    line: "        - --{{ item }}"
+    insertafter: "^.+args:$"
+  with_items:
+    - kubelet-preferred-address-types=InternalIP
+    - kubelet-insecure-tls
+
+- name: Deploy metrics-server into the cluster.
+  community.kubernetes.k8s:
+    state: present
+    src: /tmp/metrics-server.yaml
+    wait: true


### PR DESCRIPTION
Add metrics server to default kind setup.
Following modified https://github.com/kubernetes-sigs/kind/issues/398#issuecomment-682072236