### PR TITLE
Add IP to subject_alt_name

### DIFF
--- a/roles/istio/tasks/self_signed.yaml
+++ b/roles/istio/tasks/self_signed.yaml
@@ -40,6 +40,7 @@
     extended_key_usage:
       - serverAuth
     subject_alt_name: # TODO: put istio-ingressgateway and istio-system into variables? {{service}} {{namespace}}
+      - "IP:{{ istio_external_ip }}"
       - "DNS:istio-ingressgateway"
       - "DNS:istio-ingressgateway.istio-system"
       - "DNS:istio-ingressgateway.istio-system.svc"


### PR DESCRIPTION
Prometheus alertmanager complains if the certificate does not contain IP SANs if the external protocol for seldon deploy is `https`

```bash
level=error ts=2021-10-14T16:01:06.217Z caller=dispatch.go:310 component=dispatcher msg="Notify for alerts failed" num_alerts=1 err="deploy-webhook/webhook[0]: notify retry canceled after 17 attempts: Post \"http://seldon-deploy.seldon-system:80/seldon-deploy/api/v1alpha1/webhooks/firing-alert\": Post \"https://34.147.77.106/auth/realms/deploy-realm/protocol/openid-connect/token\": x509: cannot validate certificate for 34.147.77.106 because it doesn't contain any IP SANs"
```

This PR adds it