### PR TITLE
Fix Argo RBAC task name

### DIFF
--- a/roles/argo_workflows/tasks/rbac.yaml
+++ b/roles/argo_workflows/tasks/rbac.yaml
@@ -38,7 +38,7 @@
   loop_control:
     loop_var: loop_namespace
 
-- name: Create Workflow Role
+- name: Create Workflow ServiceAccount
   kubernetes.core.k8s:
     state: present
     name: workflow


### PR DESCRIPTION
Rename Argo RBAC task to reflect focus on service account