### PR TITLE
Parameterise resource cache location

### DIFF
--- a/roles/efk_opendistro_stack/defaults/main.yaml
+++ b/roles/efk_opendistro_stack/defaults/main.yaml
@@ -1,4 +1,6 @@
 ---
+seldon_cache_directory: "{{ ansible_env.HOME }}/.cache/seldon"
+
 seldon_system_namespace: seldon-system
 elastic_opendistro_namespace: seldon-logs
 

--- a/roles/efk_opendistro_stack/tasks/get_resources.yaml
+++ b/roles/efk_opendistro_stack/tasks/get_resources.yaml
@@ -3,5 +3,5 @@
   ansible.builtin.git:
     version: "{{ elastic_opendistro_version }}"
     repo: "{{ elastic_opendistro_repo }}"
-    dest: "{{ inventory_dir }}/.resources/opendistro-build"
+    dest: "{{ seldon_cache_directory }}/opendistro-build"
     force: yes

--- a/roles/efk_opendistro_stack/tasks/install_elasticsearch.yaml
+++ b/roles/efk_opendistro_stack/tasks/install_elasticsearch.yaml
@@ -3,7 +3,7 @@
   kubernetes.core.helm:
     name: elasticsearch
     release_namespace: "{{ elastic_opendistro_namespace }}"
-    chart_ref: "{{ inventory_dir }}/.resources/opendistro-build/helm/opendistro-es"
+    chart_ref: "{{ seldon_cache_directory }}/opendistro-build/helm/opendistro-es"
     values: "{{ elastic_opendistro_values }}"
 
 - name: Wait for Elasticsearch deployments

--- a/roles/istio/defaults/main.yaml
+++ b/roles/istio/defaults/main.yaml
@@ -1,4 +1,6 @@
 ---
+seldon_cache_directory: "{{ ansible_env.HOME }}/.cache/seldon"
+
 istio_version: 1.10.3
 istio_verify_install: true
 istio_create_seldon_gateway: true

--- a/roles/istio/tasks/main.yaml
+++ b/roles/istio/tasks/main.yaml
@@ -5,7 +5,7 @@
   register: istio_directory
 
 
-- name: "Create .resources directory if does not exist: {{ seldon_cache_directory }}/"
+- name: "Create resources directory if does not exist: {{ seldon_cache_directory }}/"
   ansible.builtin.file:
     path: "{{ seldon_cache_directory }}/"
     state: directory

--- a/roles/istio/tasks/main.yaml
+++ b/roles/istio/tasks/main.yaml
@@ -1,13 +1,13 @@
 ---
 - name: Check if Istio {{ istio_version }} already downloaded.
   stat:
-    path: "{{ inventory_dir }}/.resources/istio-{{ istio_version }}"
+    path: "{{ seldon_cache_directory }}/istio-{{ istio_version }}"
   register: istio_directory
 
 
-- name: "Create .resources directory if does not exist: {{ inventory_dir }}/.resources/"
+- name: "Create .resources directory if does not exist: {{ seldon_cache_directory }}/"
   ansible.builtin.file:
-    path: "{{ inventory_dir }}/.resources/"
+    path: "{{ seldon_cache_directory }}/"
     state: directory
     mode: '0755'
 
@@ -15,7 +15,7 @@
 - name: Download Istio {{ istio_version }}
   shell: "curl -L https://istio.io/downloadIstio | ISTIO_VERSION={{ istio_version }} sh -"
   args:
-    chdir: "{{ inventory_dir }}/.resources"
+    chdir: "{{ seldon_cache_directory }}"
     warn: false
   when: istio_directory.stat.exists == false
 
@@ -23,13 +23,13 @@
 - name: Install Istio {{ istio_version }}
   shell: "./bin/istioctl install --set profile=default -y"
   args:
-    chdir: "{{ inventory_dir }}/.resources/istio-{{ istio_version }}"
+    chdir: "{{ seldon_cache_directory }}/istio-{{ istio_version }}"
 
 
 - name: Verify Install Istio {{ istio_version }}
   shell: "./bin/istioctl verify-install"
   args:
-    chdir: "{{ inventory_dir }}/.resources/istio-{{ istio_version }}"
+    chdir: "{{ seldon_cache_directory }}/istio-{{ istio_version }}"
   when: istio_verify_install | bool
 
 

--- a/roles/iter8/defaults/main.yaml
+++ b/roles/iter8/defaults/main.yaml
@@ -1,4 +1,6 @@
 ---
+seldon_cache_directory: "{{ ansible_env.HOME }}/.cache/seldon"
+
 iter8_namespace: iter8-system
 iter8_version: master
 

--- a/roles/iter8/tasks/main.yaml
+++ b/roles/iter8/tasks/main.yaml
@@ -3,16 +3,16 @@
   ansible.builtin.git:
     version: "{{ iter8_version }}"
     repo: "{{ iter8_repo }}"
-    dest: "{{ inventory_dir }}/.resources/iter8"
+    dest: "{{ seldon_cache_directory }}/iter8"
     force: yes
   when: iter8_source_dir is undefined
 
 - name: Set Iter8 Directory
-  set_fact: iter8_source_dir="{{ inventory_dir }}/.resources/iter8"
+  set_fact: iter8_source_dir="{{ seldon_cache_directory }}/iter8"
   when: iter8_source_dir is undefined
 
 - name: Install Iter8
-  ansible.builtin.shell: "kustomize build {{ inventory_dir }}/.resources/iter8/install/core | kubectl apply -n {{ iter8_namespace }} -f -"
+  ansible.builtin.shell: "kustomize build {{ seldon_cache_directory }}/iter8/install/core | kubectl apply -n {{ iter8_namespace }} -f -"
 
 - name: Wait for Iter8 deployments
   kubernetes.core.k8s_info:

--- a/roles/iter8/tasks/main.yaml
+++ b/roles/iter8/tasks/main.yaml
@@ -8,7 +8,8 @@
   when: iter8_source_dir is undefined
 
 - name: Set Iter8 Directory
-  set_fact: iter8_source_dir="{{ seldon_cache_directory }}/iter8"
+  set_fact:
+    iter8_source_dir: "{{ seldon_cache_directory }}/iter8"
   when: iter8_source_dir is undefined
 
 - name: Install Iter8

--- a/roles/kind/defaults/main.yaml
+++ b/roles/kind/defaults/main.yaml
@@ -1,4 +1,6 @@
 ---
+seldon_cache_directory: "{{ ansible_env.HOME }}/.cache/seldon"
+
 kind_cluster_name: ansible
 kind_image_version: kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
 

--- a/roles/kind/tasks/create_cluster.yaml
+++ b/roles/kind/tasks/create_cluster.yaml
@@ -7,7 +7,7 @@
 - name: "Start KinD Cluster: '{{ kind_cluster_name }}'"
   command:
     argv:
-      - "{{ inventory_dir }}/.resources/kind-{{ kind_version }}"
+      - "{{ seldon_cache_directory }}/kind-{{ kind_version }}"
       - create
       - cluster
       - --name={{ kind_cluster_name }}
@@ -24,7 +24,7 @@
 - name: "Export kubeconfig for KinD Cluster: '{{ kind_cluster_name }}'"
   command:
     argv:
-      - "{{ inventory_dir }}/.resources/kind-{{ kind_version }}"
+      - "{{ seldon_cache_directory }}/kind-{{ kind_version }}"
       - export
       - kubeconfig
       - --name={{ kind_cluster_name }}

--- a/roles/kind/tasks/download_kind.yaml
+++ b/roles/kind/tasks/download_kind.yaml
@@ -1,24 +1,24 @@
 ---
 - name: Check if Kind {{ kind_version }} already downloaded
   stat:
-    path: "{{ inventory_dir }}/.resources/kind-{{ kind_version }}"
+    path: "{{ seldon_cache_directory }}/kind-{{ kind_version }}"
   register: kind_binary
 
-- name: "Create .resources directory if does not exist: {{ inventory_dir }}/.resources/"
+- name: "Create .resources directory if does not exist: {{ seldon_cache_directory }}/"
   ansible.builtin.file:
-    path: "{{ inventory_dir }}/.resources/"
+    path: "{{ seldon_cache_directory }}/"
     state: directory
     mode: '0755'
 
 - name: Download Kind {{ kind_version }} binary
   shell: "curl -Lo kind-{{ kind_version }} {{ kind_url }}"
   args:
-    chdir: "{{ inventory_dir }}/.resources"
+    chdir: "{{ seldon_cache_directory }}"
     warn: false
   when: kind_binary.stat.exists == false
 
 - name: Make Kind {{ kind_version }} binary executable
   ansible.builtin.file:
-    path: "{{ inventory_dir }}/.resources/kind-{{ kind_version }}"
+    path: "{{ seldon_cache_directory }}/kind-{{ kind_version }}"
     state: file
     mode: '0755'

--- a/roles/kind/tasks/download_kind.yaml
+++ b/roles/kind/tasks/download_kind.yaml
@@ -4,7 +4,7 @@
     path: "{{ seldon_cache_directory }}/kind-{{ kind_version }}"
   register: kind_binary
 
-- name: "Create .resources directory if does not exist: {{ seldon_cache_directory }}/"
+- name: "Create resources directory if does not exist: {{ seldon_cache_directory }}/"
   ansible.builtin.file:
     path: "{{ seldon_cache_directory }}/"
     state: directory

--- a/roles/postgres_operator/defaults/main.yaml
+++ b/roles/postgres_operator/defaults/main.yaml
@@ -1,4 +1,6 @@
 ---
+seldon_cache_directory: "{{ ansible_env.HOME }}/.cache/seldon"
+
 postgres_operator_namespace: postgres
 
 postgres_operator_repo: https://github.com/zalando/postgres-operator.git

--- a/roles/postgres_operator/tasks/get_resources.yaml
+++ b/roles/postgres_operator/tasks/get_resources.yaml
@@ -3,5 +3,5 @@
   ansible.builtin.git:
     version: "{{ postgres_operator_version }}"
     repo: "{{ postgres_operator_repo }}"
-    dest: "{{ inventory_dir }}/.resources/postgres-operator"
+    dest: "{{ seldon_cache_directory }}/postgres-operator"
     force: yes

--- a/roles/postgres_operator/tasks/install_postgres_operator.yaml
+++ b/roles/postgres_operator/tasks/install_postgres_operator.yaml
@@ -3,6 +3,6 @@
   kubernetes.core.helm:
     name: postgres-operator
     release_namespace: "{{ postgres_operator_namespace }}"
-    chart_ref: "{{ inventory_dir }}/.resources/postgres-operator/charts/postgres-operator"
+    chart_ref: "{{ seldon_cache_directory }}/postgres-operator/charts/postgres-operator"
     values: "{{ postgres_operator_values }}"
     values_files: "{{ postgres_operator_values_files }}"

--- a/roles/seldon_core/defaults/main.yaml
+++ b/roles/seldon_core/defaults/main.yaml
@@ -1,4 +1,6 @@
 ---
+seldon_cache_directory: "{{ ansible_env.HOME }}/.cache/seldon"
+
 seldon_system_namespace: seldon-system
 seldon_core_version: master
 

--- a/roles/seldon_core/tasks/main.yaml
+++ b/roles/seldon_core/tasks/main.yaml
@@ -6,12 +6,12 @@
   ansible.builtin.git:
     version: "{{ seldon_core_version }}"
     repo: "{{ seldon_core_repo }}"
-    dest: "{{ inventory_dir }}/.resources/seldon-core"
+    dest: "{{ seldon_cache_directory }}/seldon-core"
     force: yes
   when: seldon_core_source_dir is undefined
 
 - name: Set Seldon Core Directory
-  set_fact: seldon_core_source_dir="{{ inventory_dir }}/.resources/seldon-core"
+  set_fact: seldon_core_source_dir="{{ seldon_cache_directory }}/seldon-core"
   when: seldon_core_source_dir is undefined
 
 - name: Deploy Seldon Core

--- a/roles/seldon_core/tasks/main.yaml
+++ b/roles/seldon_core/tasks/main.yaml
@@ -11,7 +11,8 @@
   when: seldon_core_source_dir is undefined
 
 - name: Set Seldon Core Directory
-  set_fact: seldon_core_source_dir="{{ seldon_cache_directory }}/seldon-core"
+  set_fact:
+    seldon_core_source_dir: "{{ seldon_cache_directory }}/seldon-core"
   when: seldon_core_source_dir is undefined
 
 - name: Deploy Seldon Core


### PR DESCRIPTION
This allows:
* Users deciding where to cache local resources, as they are no longer locked into a hard-coded location.
* Better caching as users may have checkouts in different locations, e.g. for stable vs. dev variants.
* Multiple users (whether human or automated) to work against the same collection checkout/installation, as their runs can use different cache locations.

It has the added benefit that it's in line with the default value for `XDG_CACHE_HOME`, which is a plausible location for a user to search for cached resources.

Closes https://github.com/SeldonIO/ansible-k8s-collection/issues/14