### PR TITLE
add bitnami fluentd role

### DIFF
--- a/roles/bitnami_fluentd/defaults/main.yaml
+++ b/roles/bitnami_fluentd/defaults/main.yaml
@@ -1,0 +1,6 @@
+---
+bitnami_fluentd_namespace: seldon-logs
+bitnami_fluentd_name: fluentd
+
+bitnami_fluentd_chart_version: 4.1.6
+bitnami_fluentd_values: {}

--- a/roles/bitnami_fluentd/tasks/main.yaml
+++ b/roles/bitnami_fluentd/tasks/main.yaml
@@ -1,0 +1,16 @@
+---
+- name: "Create a k8s namespaces: {{ bitnami_fluentd_namespace }}"
+  kubernetes.core.k8s:
+    name: "{{ bitnami_fluentd_namespace }}"
+    api_version: v1
+    kind: Namespace
+    state: present
+
+- name: Install Audit Fluentd
+  kubernetes.core.helm:
+    name: "{{ bitnami_fluentd_name }}"
+    release_namespace: "{{ bitnami_fluentd_namespace }}"
+    chart_repo_url: "https://charts.bitnami.com/bitnami"
+    chart_ref: "fluentd"
+    chart_version: "{{ bitnami_fluentd_chart_version }}"
+    values: "{{ bitnami_fluentd_values }}"

--- a/roles/efk_opendistro_stack/defaults/main.yaml
+++ b/roles/efk_opendistro_stack/defaults/main.yaml
@@ -16,5 +16,5 @@ elastic_opendistro_wait_for_deployments: true
 
 
 fluentd_chart_version: 10.0.1
-flutend_values: {}
+fluentd_values: {}
 fluentd_wait_for_deployments: true


### PR DESCRIPTION
Add bitnami fluentd role. This is generic role to install fluentd from bitnami charts. The name under which it will be installed is configurable so role can be used multiple times if required. 