### PR TITLE
Allow non-templated files as extra Prometheus config

### DIFF
--- a/roles/seldon_core_analytics/defaults/main.yaml
+++ b/roles/seldon_core_analytics/defaults/main.yaml
@@ -5,4 +5,5 @@ seldon_core_analytics_values: {}
 seldon_core_analytics_wait_for_deployments: true
 seldon_core_analytics_istio_external_ip_required: false
 
+seldon_core_analytics_extra_files: []
 seldon_core_analytics_extra_templates: []

--- a/roles/seldon_core_analytics/defaults/main.yaml
+++ b/roles/seldon_core_analytics/defaults/main.yaml
@@ -5,5 +5,4 @@ seldon_core_analytics_values: {}
 seldon_core_analytics_wait_for_deployments: true
 seldon_core_analytics_istio_external_ip_required: false
 
-seldon_core_analytics_extra_files: []
-seldon_core_analytics_extra_templates: []
+seldon_core_analytics_extra_resources: []

--- a/roles/seldon_core_analytics/tasks/main.yaml
+++ b/roles/seldon_core_analytics/tasks/main.yaml
@@ -20,6 +20,12 @@
     istio_external_ip: "{{ istio_web_service.resources[0].status.loadBalancer.ingress[0].ip }}"
   when: seldon_core_analytics_istio_external_ip_required | bool
 
+- name: Create Extra Resources from Files
+  kubernetes.core.k8s:
+    namespace: "{{ seldon_system_namespace }}"
+    src: "{{ item }}"
+  with_items: "{{ seldon_core_analytics_extra_files }}"
+
 - name: Create Extra Resources from Templates
   kubernetes.core.k8s:
     namespace: "{{ seldon_system_namespace }}"

--- a/roles/seldon_core_analytics/tasks/main.yaml
+++ b/roles/seldon_core_analytics/tasks/main.yaml
@@ -20,17 +20,11 @@
     istio_external_ip: "{{ istio_web_service.resources[0].status.loadBalancer.ingress[0].ip }}"
   when: seldon_core_analytics_istio_external_ip_required | bool
 
-- name: Create Extra Resources from Files
+- name: Create Extra Resources
   kubernetes.core.k8s:
     namespace: "{{ seldon_system_namespace }}"
-    src: "{{ item }}"
-  with_items: "{{ seldon_core_analytics_extra_files }}"
-
-- name: Create Extra Resources from Templates
-  kubernetes.core.k8s:
-    namespace: "{{ seldon_system_namespace }}"
-    template: "{{ item }}"
-  with_items: "{{ seldon_core_analytics_extra_templates }}"
+    definition: "{{ item }}"
+  with_items: "{{ seldon_core_analytics_extra_resources }}"
 
 - name: Install Seldon Core Analytics
   kubernetes.core.helm:


### PR DESCRIPTION
When using raw config files which do not require templating, it's very inconvenient to have to side-step Jinja templating, e.g.  with `{% raw %}` directives.
It's much easier to allow users to provide raw, non-templated files directly, _in addition_ to the existing support for templates.