### PR TITLE
deindent if-else-endif directives in gateway template

### DIFF
--- a/roles/istio/templates/default-seldon-gateway.yaml.j2
+++ b/roles/istio/templates/default-seldon-gateway.yaml.j2
@@ -22,11 +22,11 @@ spec:
       name: https
       protocol: HTTPS
     tls:
-      {% if istio_self_signed_certs | bool %}
+{% if istio_self_signed_certs | bool %}
       serverCertificate: /etc/istio/ingressgateway-certs/tls.crt
       privateKey: /etc/istio/ingressgateway-certs/tls.key
-      {% else %}
+{% else %}
       credentialName: "{{ istio_ingress_cert_secret }}"
-      {% endif %}
+{% endif %}
       mode: SIMPLE
 {% endif %}


### PR DESCRIPTION
Fixes
```
fatal: [localhost]: FAILED! => {"msg": "An unhandled exception occurred while templating '{{ lookup('template', 'default-seldon-gateway.yaml.j2') | from_yaml }}'. Error was a <class 'yaml.scanner.ScannerError'>, original message: mapping values are not allowed here\n  in \"<unicode string>\", line 25, column 27:\n                credentialName: \"seldon-deploy-cert-tls\"\n   
```
nicely formatted as
```
{"msg": "An unhandled exception occurred while templating '{{ lookup('template', 'default-seldon-gateway.yaml.j2') | from_yaml }}'. Error was a <class 'yaml.parser.ParserError'>, original message: while parsing a block mapping
  in "<unicode string>", line 17, column 5:
      - hosts:
        ^
expected <block end>, but found '<block mapping start>'
  in "<unicode string>", line 25, column 7:
          privateKey: /etc/istio/ingressga ... 
          ^"}
```