### PR TITLE
Use latest MinIO charts since relocation

### DIFF
--- a/roles/minio/defaults/main.yaml
+++ b/roles/minio/defaults/main.yaml
@@ -1,6 +1,6 @@
 ---
 minio_namespace: minio-system
-minio_chart_version: 8.0.10
+minio_chart_version: '3.2.0'
 
 minio_access_key: minioadmin
 minio_secret_key: minioadmin

--- a/roles/minio/tasks/install.yaml
+++ b/roles/minio/tasks/install.yaml
@@ -11,6 +11,7 @@
       rootPassword: "{{ minio_secret_key }}"
       service:
         type: "{{ minio_service_type }}"
+      mode: standalone
 
 - name: Echo message about client configuration
   ansible.builtin.debug:

--- a/roles/minio/tasks/install.yaml
+++ b/roles/minio/tasks/install.yaml
@@ -7,8 +7,8 @@
     chart_version: "{{ minio_chart_version }}"
     chart_repo_url: "https://charts.min.io/"
     values:
-      accessKey: "{{ minio_access_key }}"
-      secretKey: "{{ minio_secret_key }}"
+      rootUser: "{{ minio_access_key }}"
+      rootPassword: "{{ minio_secret_key }}"
       service:
         type: "{{ minio_service_type }}"
 

--- a/roles/minio/tasks/install.yaml
+++ b/roles/minio/tasks/install.yaml
@@ -5,7 +5,7 @@
     release_namespace: "{{ minio_namespace }}"
     chart_ref: "minio"
     chart_version: "{{ minio_chart_version }}"
-    chart_repo_url: "https://helm.min.io/"
+    chart_repo_url: "https://charts.min.io/"
     values:
       accessKey: "{{ minio_access_key }}"
       secretKey: "{{ minio_secret_key }}"


### PR DESCRIPTION
MinIO charts are no longer available at helm.min.io, but rather than charts.min.io.
The chart versions are also different, with 3.2.0 being the latest at the time of writing.