### PR TITLE
Replace deprecated include directive with import_tasks

### DIFF
--- a/roles/argo_workflows/tasks/main.yaml
+++ b/roles/argo_workflows/tasks/main.yaml
@@ -23,5 +23,5 @@
   when: argo_workflows_wait_for_deployments | bool
 
 - name: Configure Service RBAC
-  include: rbac.yaml
+  import_tasks: rbac.yaml
   when: argo_workflows_configure_rbac | bool

--- a/roles/certmanager/tasks/main.yaml
+++ b/roles/certmanager/tasks/main.yaml
@@ -15,5 +15,5 @@
   when: certmanager_wait_for_deployments | bool
 
 - name: Configure Letsencrypt certificates
-  include: letsencrypt.yaml
+  import_tasks: letsencrypt.yaml
   when: certmanager_use_letsencrypt | bool

--- a/roles/efk_opendistro_stack/tasks/main.yaml
+++ b/roles/efk_opendistro_stack/tasks/main.yaml
@@ -1,15 +1,15 @@
 ---
 - name: Create Namespaces
-  include: namespaces.yaml
+  import_tasks: namespaces.yaml
 
 - name: Create Secrets
-  include: secrets.yaml
+  import_tasks: secrets.yaml
 
 - name: Download Resources
-  include: get_resources.yaml
+  import_tasks: get_resources.yaml
 
 - name: Install Elasticsearch by OpenDistro
-  include: install_elasticsearch.yaml
+  import_tasks: install_elasticsearch.yaml
 
 - name: Install Fluentd
-  include: install_fluentd.yaml
+  import_tasks: install_fluentd.yaml

--- a/roles/istio/tasks/certificates.yaml
+++ b/roles/istio/tasks/certificates.yaml
@@ -26,7 +26,7 @@
   register: tmp_cert_dir
 
 - name: Generate Self Signed Server SSL Certs from Self Signed CA
-  include: self_signed.yaml
+  import_tasks: self_signed.yaml
 
 - name: Set fact about Server SSL Certs Paths
   set_fact:

--- a/roles/istio/tasks/main.yaml
+++ b/roles/istio/tasks/main.yaml
@@ -41,5 +41,5 @@
 
 
 - name: Configure certificates
-  include: certificates.yaml
+  import_tasks: certificates.yaml
   when: istio_self_signed_certs | bool

--- a/roles/keda/tasks/main.yaml
+++ b/roles/keda/tasks/main.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Create Namespaces
-  include: namespaces.yaml
+  import_tasks: namespaces.yaml
 
 - name: Install KEDA
-  include: install.yaml
+  import_tasks: install.yaml
 

--- a/roles/kind/tasks/main.yaml
+++ b/roles/kind/tasks/main.yaml
@@ -1,14 +1,14 @@
 ---
 - name: Get Kind Binary
-  include: download_kind.yaml
+  import_tasks: download_kind.yaml
   when: kind_download_cli | bool
 
 - name: Create Kind Cluster
-  include: create_cluster.yaml
+  import_tasks: create_cluster.yaml
 
 - name: Create and set default namespace
-  include: default_namespace.yaml
+  import_tasks: default_namespace.yaml
 
 - name: Deploy metrics server
-  include: metrics_server.yaml
+  import_tasks: metrics_server.yaml
   when: kind_deploy_metrics_server | bool

--- a/roles/knative_eventing/tasks/main.yaml
+++ b/roles/knative_eventing/tasks/main.yaml
@@ -44,5 +44,5 @@
   when: knative_eventing_wait_for_deployments | bool
 
 - name: Create default broker
-  include: create_broker.yaml
+  import_tasks: create_broker.yaml
   when: knative_eventing_create_default_broker | bool

--- a/roles/minio/tasks/main.yaml
+++ b/roles/minio/tasks/main.yaml
@@ -1,9 +1,9 @@
 ---
 - name: Create Namespaces
-  include: namespaces.yaml
+  import_tasks: namespaces.yaml
 
 - name: Install Minio
-  include: install.yaml
+  import_tasks: install.yaml
 
 - name: Create Secrets
-  include: secrets.yaml
+  import_tasks: secrets.yaml

--- a/roles/postgres_operator/tasks/main.yaml
+++ b/roles/postgres_operator/tasks/main.yaml
@@ -1,9 +1,9 @@
 ---
 - name: Create Namespaces
-  include: namespaces.yaml
+  import_tasks: namespaces.yaml
 
 - name: Download Resources
-  include: get_resources.yaml
+  import_tasks: get_resources.yaml
 
 - name: Install Postgres Operator
-  include: install_postgres_operator.yaml
+  import_tasks: install_postgres_operator.yaml

--- a/roles/seldon_core/tasks/main.yaml
+++ b/roles/seldon_core/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Create Namespaces
-  include: namespaces.yaml
+  import_tasks: namespaces.yaml
 
 - name: Git clone Seldon Core repo and checkout {{ seldon_core_version }}
   ansible.builtin.git:

--- a/roles/strimzi_kafka/tasks/main.yaml
+++ b/roles/strimzi_kafka/tasks/main.yaml
@@ -1,14 +1,14 @@
 ---
 - name: Create Namespaces
-  include: namespaces.yaml
+  import_tasks: namespaces.yaml
 
 - name: Install Kafka Operator
-  include: install.yaml
+  import_tasks: install.yaml
 
 - name: Create Kafka Cluster
-  include: cluster.yaml
+  import_tasks: cluster.yaml
   when: strimzi_kafka_create_cluster | bool
 
 - name: Install metrics
-  include: metrics.yaml
+  import_tasks: metrics.yaml
   when: strimzi_kafka_create_metrics | bool


### PR DESCRIPTION
The 'include' directive will be deprecated as of Ansible 2.16.
This is a pre-emptive change to avoid that time-bomb,
and also because the newer directives are more explicit and
better defined in their behaviours and trade-offs.

See https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse.html#dynamic-vs-static