### PR TITLE
Add handler for Knative Eventing broker installation

### DIFF
--- a/roles/knative_eventing/defaults/main.yaml
+++ b/roles/knative_eventing/defaults/main.yaml
@@ -11,8 +11,6 @@ knative_eventing_broker: "{{ knative_eventing_download_url }}/{{ knative_eventin
 # until: https://github.com/yaml/pyyaml/pull/394 is merged
 knative_eventing_workaround_issue_189: true
 
-knative_eventing_wait_for_deployments: true
-
 knative_eventing_create_default_broker: false
 knative_eventing_default_broker_name: default
 knative_eventing_default_broker_namespace: default

--- a/roles/knative_eventing/handlers/main.yaml
+++ b/roles/knative_eventing/handlers/main.yaml
@@ -1,3 +1,3 @@
 ---
 - name: "Create Knative Eventing broker"
-  import_tasks: create_broker.yaml
+  include_tasks: create_broker.yaml

--- a/roles/knative_eventing/handlers/main.yaml
+++ b/roles/knative_eventing/handlers/main.yaml
@@ -1,0 +1,3 @@
+---
+- name: "Create Knative Eventing broker"
+  import_tasks: create_broker.yaml

--- a/roles/knative_eventing/tasks/create_broker.yaml
+++ b/roles/knative_eventing/tasks/create_broker.yaml
@@ -14,7 +14,7 @@
   shell: "kubectl rollout status -n knative-eventing deploy/{{ item }}"
   with_items: "{{ knative_eventing_deployment_names }}"
 
-- name: "Create a k8s namespace {{ knative_eventing_default_broker_namespace }} "
+- name: "Create k8s namespace for default broker"
   kubernetes.core.k8s:
     name: "{{ knative_eventing_default_broker_namespace }}"
     api_version: v1

--- a/roles/knative_eventing/tasks/create_broker.yaml
+++ b/roles/knative_eventing/tasks/create_broker.yaml
@@ -22,7 +22,7 @@
     state: present
   when: knative_eventing_create_default_broker | bool
 
-- name: Create default broker
+- name: "Create default broker"
   kubernetes.core.k8s:
     state: present
     definition:

--- a/roles/knative_eventing/tasks/create_broker.yaml
+++ b/roles/knative_eventing/tasks/create_broker.yaml
@@ -20,6 +20,7 @@
     api_version: v1
     kind: Namespace
     state: present
+  when: knative_eventing_create_default_broker | bool
 
 - name: Create default broker
   kubernetes.core.k8s:

--- a/roles/knative_eventing/tasks/create_broker.yaml
+++ b/roles/knative_eventing/tasks/create_broker.yaml
@@ -1,4 +1,19 @@
 ---
+- name: "Get list of deployments in Knative Eventing namespace"
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Deployment
+    namespace: knative-eventing
+  register: knative_eventing_deployments
+
+- name: "Extract names of deployments in knative seriving namespace"
+  set_fact:
+    knative_eventing_deployment_names: "{{ knative_eventing_deployments.resources | map(attribute='metadata') | map(attribute='name') }}"
+
+- name: "Wait for Knative Eventing deployments"
+  shell: "kubectl rollout status -n knative-eventing deploy/{{ item }}"
+  with_items: "{{ knative_eventing_deployment_names }}"
+
 - name: "Create a k8s namespace {{ knative_eventing_default_broker_namespace }} "
   kubernetes.core.k8s:
     name: "{{ knative_eventing_default_broker_namespace }}"
@@ -15,3 +30,4 @@
       metadata:
         name: "{{ knative_eventing_default_broker_name }}"
         namespace: "{{ knative_eventing_default_broker_namespace }}"
+  when: knative_eventing_create_default_broker | bool

--- a/roles/knative_eventing/tasks/install.yaml
+++ b/roles/knative_eventing/tasks/install.yaml
@@ -1,0 +1,20 @@
+---
+- name: Install Knative Eventing
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('url', item, split_lines=False) }}"
+  with_items:
+    - "{{ knative_eventing_crds }}"
+    - "{{ knative_eventing_core }}"
+    - "{{ knative_eventing_channel }}"
+    - "{{ knative_eventing_broker }}"
+  when: (knative_eventing_workaround_issue_189 | bool) == false
+
+- name: Install Knative Eventing (direct kubectl to workaround issue 189)
+  shell: "kubectl apply -f {{ item }}"
+  with_items:
+    - "{{ knative_eventing_crds }}"
+    - "{{ knative_eventing_core }}"
+    - "{{ knative_eventing_channel }}"
+    - "{{ knative_eventing_broker }}"
+  when: knative_eventing_workaround_issue_189 | bool

--- a/roles/knative_eventing/tasks/main.yaml
+++ b/roles/knative_eventing/tasks/main.yaml
@@ -1,7 +1,4 @@
 ---
 - name: "Install Knative Eventing"
   import_tasks: install.yaml
-
-- name: "Notify Knative Eventing broker installation handler"
-  command: "true"
   notify: "Create Knative Eventing broker"

--- a/roles/knative_eventing/tasks/main.yaml
+++ b/roles/knative_eventing/tasks/main.yaml
@@ -2,16 +2,6 @@
 - name: "Install Knative Eventing"
   import_tasks: install.yaml
 
-- name: "Sleep for 5 seconds to give deployments time to appear"
-  wait_for:
-    timeout: 5
-  when: knative_eventing_wait_for_deployments | bool
-
-- name: "Install broker (synchronous)"
-  import_tasks: create_broker.yaml
-  when: knative_eventing_wait_for_deployments | bool
-
-- name: "Install broker (asynchronous)"
+- name: "Notify Knative Eventing broker installation handler"
   command: "true"
   notify: "Create Knative Eventing broker"
-  when: not (knative_eventing_wait_for_deployments | bool)

--- a/roles/knative_eventing/tasks/main.yaml
+++ b/roles/knative_eventing/tasks/main.yaml
@@ -13,5 +13,5 @@
 
 - name: "Install broker (asynchronous)"
   command: "true"
-  notify: "create Knative Eventing broker"
+  notify: "Create Knative Eventing broker"
   when: not (knative_eventing_wait_for_deployments | bool)

--- a/roles/knative_eventing/tasks/main.yaml
+++ b/roles/knative_eventing/tasks/main.yaml
@@ -1,24 +1,6 @@
 ---
-- name: Install Knative Eventing
-  kubernetes.core.k8s:
-    state: present
-    definition: "{{ lookup('url', item, split_lines=False) }}"
-  with_items:
-    - "{{ knative_eventing_crds }}"
-    - "{{ knative_eventing_core }}"
-    - "{{ knative_eventing_channel }}"
-    - "{{ knative_eventing_broker }}"
-  when: (knative_eventing_workaround_issue_189 | bool) == false
-
-- name: Install Knative Eventing (direct kubectl to workaround issue 189)
-  shell: "kubectl apply -f {{ item }}"
-  with_items:
-    - "{{ knative_eventing_crds }}"
-    - "{{ knative_eventing_core }}"
-    - "{{ knative_eventing_channel }}"
-    - "{{ knative_eventing_broker }}"
-  when: knative_eventing_workaround_issue_189 | bool
-
+- name: "Install Knative Eventing"
+  import_tasks: install.yaml
 
 - name: Sleep for 5 seconds to give deployments time to appear
   wait_for:

--- a/roles/knative_eventing/tasks/main.yaml
+++ b/roles/knative_eventing/tasks/main.yaml
@@ -2,29 +2,16 @@
 - name: "Install Knative Eventing"
   import_tasks: install.yaml
 
-- name: Sleep for 5 seconds to give deployments time to appear
+- name: "Sleep for 5 seconds to give deployments time to appear"
   wait_for:
     timeout: 5
   when: knative_eventing_wait_for_deployments | bool
 
-- name: Get list of deployments in knative eventing namespace
-  kubernetes.core.k8s_info:
-    api_version: v1
-    kind: Deployment
-    namespace: knative-eventing
-  register: knative_eventing_deployments
-  when: knative_eventing_wait_for_deployments | bool
-
-- name: Extract names of deployments in knative seriving namespace
-  set_fact:
-    knative_eventing_deployment_names: "{{ knative_eventing_deployments.resources | map(attribute='metadata') | map(attribute='name') }}"
-  when: knative_eventing_wait_for_deployments | bool
-
-- name: Wait for Knative Eventing deployments
-  shell: "kubectl rollout status -n knative-eventing deploy/{{ item }}"
-  with_items: "{{ knative_eventing_deployment_names }}"
-  when: knative_eventing_wait_for_deployments | bool
-
-- name: Create default broker
+- name: "Install broker (synchronous)"
   import_tasks: create_broker.yaml
-  when: knative_eventing_create_default_broker | bool
+  when: knative_eventing_wait_for_deployments | bool
+
+- name: "Install broker (asynchronous)"
+  command: "true"
+  notify: "create Knative Eventing broker"
+  when: not (knative_eventing_wait_for_deployments | bool)


### PR DESCRIPTION
We have observed cases where trying to install the "default" Knative Eventing broker too soon after the CRD/resources installation can cause the broker to be created without the expected annotations.
This happens when the `knative_eventing_wait_for_deployments` variable is false-y.

In itself this sounds harmless, but re-running a playbook which includes the `knative_eventing` role will fail because of the validation webhook.  The error will be similar to the following:
```
'Failed to patch object: b''{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"admission webhook \\"validation.webhook.eventing.knative.dev\\" denied the request: validation failed: Immutable fields changed (-old +new): annotations\\n{string}:\\n\\t-: \\"\\"\\n\\t+: \\"MTChannelBasedBroker\\"\\n","reason":"BadRequest","code":400}\n'''
```

Rather than waiting for Knative Eventing deployments to be available synchronously, such as the webhook and controller, we can allow other components to be installed in the meantime and instead use an Ansible handler to install the broker at the end of the playbook.

This should improve installation time when multiple components are being installed, and should not hurt installation time significantly otherwise.