### PR TITLE
Add retry logic for Bitnami Fluentd chart installation

### DIFF
--- a/roles/bitnami_fluentd/defaults/main.yaml
+++ b/roles/bitnami_fluentd/defaults/main.yaml
@@ -4,3 +4,6 @@ bitnami_fluentd_name: fluentd
 
 bitnami_fluentd_chart_version: 4.1.6
 bitnami_fluentd_values: {}
+
+bitnami_fluentd_retries: 5
+bitnami_fluentd_retry_delay_seconds: 10

--- a/roles/bitnami_fluentd/tasks/main.yaml
+++ b/roles/bitnami_fluentd/tasks/main.yaml
@@ -14,3 +14,7 @@
     chart_ref: "fluentd"
     chart_version: "{{ bitnami_fluentd_chart_version }}"
     values: "{{ bitnami_fluentd_values }}"
+  retries: "{{ bitnami_fluentd_retries }}"
+  delay: "{{ bitnami_fluentd_retry_delay_seconds }}"
+  register: _bitnami_fluentd_install_status
+  until: not _bitnami_fluentd_install_status.failed


### PR DESCRIPTION
This has been raised as a flaky task previously due to 'https://charts.bitnami.com/bitnami' being occasionally unreachable.
Adding retries should help to work past temporary connectivity issues.