### PR TITLE
Bump ArgoCD chart version to fix CVE 2022-24348

### DIFF
--- a/roles/argocd/defaults/main.yaml
+++ b/roles/argocd/defaults/main.yaml
@@ -1,6 +1,6 @@
 ---
 argocd_namespace: argocd
-argocd_chart_version: 3.9.0
+argocd_chart_version: 3.33.7
 
 argocd_wait_for_deployments: true
 argocd_values: {}


### PR DESCRIPTION
ArgoCD chart version 3.33.7 corresponds to application version 2.2.5.
The CVE was fixed in version 2.2.4, for the 2.2.x line of releases.