### PR TITLE
Support Gitea setup via VirtualService

### DIFF
--- a/roles/gitea/tasks/main.yaml
+++ b/roles/gitea/tasks/main.yaml
@@ -66,7 +66,7 @@
 
     - name: "Get IP for ingress gateway"
       set_fact:
-        gitea_external_address: "{{ external_service.resources[0].status.loadBalancer.ingress.ip }}"
+        gitea_external_address: "{{ external_service.resources[0].status.loadBalancer.ingress[0].ip }}"
 
     - name: "Log external address"
       ansible.builtin.debug:


### PR DESCRIPTION
## Motivation
Previously, the Gitea role required using a LoadBalancer service for setting up the initial repository.
This firstly requires consuming an extra LB service and secondly may not fit in with organisational requirements if a service mesh is used.

## Changes
This PR adds support for configuring Gitea through an Istio ingress gateway (and VirtualService, "VS") as well as a LoadBalancer service.
If a VS is requested, the Gitea role will create and use this instead of creating an LB service.
If no VS is requested, it is assumed the `gitea-http` service is configured with an external LB instance.

I think this is a cleaner solution than adding more toggles for "maybe do this, then maybe do that", which is open to misconfiguration errors, or forcing the user to provide an external address to the role, which then requires more prior configuration and variables being passed around.

If we need to add support for more service meshes in the future, we may want to consider either:
* Having conditionally enabled tasks, one for each supported ingress type (plain LB, Istio, ...), or
* Requiring an ingress URI to be provided to the role.